### PR TITLE
Change ROC param to uint32

### DIFF
--- a/rtp-session.go
+++ b/rtp-session.go
@@ -65,9 +65,9 @@ func (s *RTPSession) Decode(packetData []byte) (*RTPPacket, error) {
 
 	if s.cipherID == HALF_AEAD_AES_128_GCM_AEAD_AES_128_GCM {
 		cipherKeySize := 128 / 8
-		cipherKeyEnc := s.kdf.Derive(Ke, uint64(s.roc), seq, cipherKeySize)
+		cipherKeyEnc := s.kdf.Derive(Ke, s.roc, seq, cipherKeySize)
 		//cipherKeyAuth := s.kdf.Derive(Ka, s.roc, s.seq, cipherKeySize) // not used for GCM
-		cipherSalt := s.kdf.Derive(Ks, uint64(s.roc), seq, cipherKeySize)
+		cipherSalt := s.kdf.Derive(Ks, s.roc, seq, cipherKeySize)
 
 		err := p.DecryptGCM(s.roc, cipherKeyEnc, cipherSalt)
 		if err != nil {
@@ -102,9 +102,9 @@ func (s *RTPSession) Encode(p *RTPPacket) ([]byte, error) {
 
 		// encrypt
 		cipherKeySize := 128 / 8
-		cipherKeyEnc := s.kdf.Derive(Ke, uint64(s.roc), s.seq, cipherKeySize)
+		cipherKeyEnc := s.kdf.Derive(Ke, s.roc, s.seq, cipherKeySize)
 		//cipherKeyAuth := s.kdf.Derive(Ka, s.roc, s.seq, cipherKeySize) // not used for GCM
-		cipherSalt := s.kdf.Derive(Ks, uint64(s.roc), s.seq, cipherKeySize)
+		cipherSalt := s.kdf.Derive(Ks, s.roc, s.seq, cipherKeySize)
 
 		err = p.EncryptGCM(s.roc, cipherKeyEnc, cipherSalt)
 		if err != nil {

--- a/srtp-kdf.go
+++ b/srtp-kdf.go
@@ -33,10 +33,8 @@ func NewKDF(masterKey, masterSalt []byte) (*KDF, error) {
 	}, nil
 }
 
-// TODO - why is roc 64 bits not 32
-
-func (kdf KDF) Derive(label byte, roc uint64, seq uint16, size int) []byte {
-	indexVal := (roc << 16) + uint64(seq)
+func (kdf KDF) Derive(label byte, roc uint32, seq uint16, size int) []byte {
+	indexVal := (uint64(roc) << 16) + uint64(seq)
 	index := make([]byte, 6)
 	for i := range index {
 		index[5-i] = byte(indexVal)


### PR DESCRIPTION
The ROC param was previously a `uint64` because it ended up going into a 48-bit wide index value.  But we can just make the index value a `uint64` and keep the ROC as `uint32`.